### PR TITLE
Fixes for this.table being undefined

### DIFF
--- a/lib/ConfigUtils.d.ts
+++ b/lib/ConfigUtils.d.ts
@@ -101,6 +101,5 @@ export interface IProps {
     downloadReady?: any;
     downloadComplete?: any;
     options?: any;
-    selectableCheck?: any;
 }
 export declare const propsToOptions: (props: any) => Promise<any>;

--- a/lib/ConfigUtils.js
+++ b/lib/ConfigUtils.js
@@ -75,7 +75,7 @@ exports.propsToOptions = function (props) { return __awaiter(void 0, void 0, voi
                     'groupVisibilityChanged', 'groupClick', 'groupDblClick', 'groupContext', 'groupTap', 'groupDblTap', 'groupTapHold',
                     'movableRowsSendingStart', 'movableRowsSent', 'movableRowsSentFailed', 'movableRowsSendingStop', 'movableRowsReceivingStart', 'movableRowsReceived', 'movableRowsReceivedFailed', 'movableRowsReceivingStop',
                     'validationFailed', 'clipboardCopied', 'clipboardPasted', 'clipboardPasteError',
-                    'downloadReady', 'downloadComplete', 'selectableCheck'];
+                    'downloadReady', 'downloadComplete'];
                 for (_a = 0, callbackNames_1 = callbackNames; _a < callbackNames_1.length; _a++) {
                     callbackName = callbackNames_1[_a];
                     output[callbackName] = props[callbackName] || NOOPS;

--- a/lib/React15Tabulator.js
+++ b/lib/React15Tabulator.js
@@ -120,7 +120,7 @@ var default_1 = /** @class */ (function (_super) {
         });
     };
     default_1.prototype.componentWillUnmount = function () {
-        this.table.destroy();
+        this.table && this.table.destroy();
     };
     // this is for React 15.x only
     default_1.prototype.componentWillReceiveProps = function (props) {
@@ -128,13 +128,13 @@ var default_1 = /** @class */ (function (_super) {
         if (!Utils_1.isSameArray(this.state.data, props.data)) {
             // console.log('- data changed');
             this.setState({ data: props.data }, function () {
-                _this.table.setData(_this.state.data);
+                _this.table && _this.table.setData(_this.state.data);
             });
         }
         if (!Utils_1.isSameArray(this.state.columns, props.columns)) {
             // console.log('- columns changed');
             this.setState({ columns: props.columns }, function () {
-                _this.table.setColumns(_this.state.columns);
+                _this.table && _this.table.setColumns(_this.state.columns);
             });
         }
     };
@@ -143,7 +143,7 @@ var default_1 = /** @class */ (function (_super) {
         // console.log('*** render');
         this.pickValidHTMLProps();
         var className = this.props.className;
-        return React.createElement("div", __assign({ ref: function (ref) { return (_this.ref = ref); }, "data-instance": this.mainId }, this.htmlProps, { className: className }));
+        return (React.createElement("div", __assign({ ref: function (ref) { return (_this.ref = ref); }, "data-instance": this.mainId }, this.htmlProps, { className: className })));
     };
     return default_1;
 }(React.Component));

--- a/lib/ReactTabulator.js
+++ b/lib/ReactTabulator.js
@@ -128,7 +128,7 @@ var default_1 = /** @class */ (function (_super) {
         });
     };
     default_1.prototype.componentWillUnmount = function () {
-        this.table.destroy();
+        this.table && this.table.destroy();
     };
     // React 16.5.x - "getDerivedStateFromProps" replaces both "componentWillMount" & "componentWillReceiveProps"
     // This function will be ignored when running with React 15.6.x
@@ -164,18 +164,18 @@ var default_1 = /** @class */ (function (_super) {
         // props data changed! (see: getDerivedStateFromProps)
         if (!Utils_1.isSameArray(prevState.data, this.state.data)) {
             // only when data is really different: call this.table.setData (will re-render table)
-            this.table.setData(this.state.data);
+            this.table && this.table.setData(this.state.data);
         }
         if (!Utils_1.isSameArray(prevState.columns, this.state.columns)) {
             // only when data is really different: call this.table.setData (will re-render table)
-            this.table.setColumns(this.state.columns);
+            this.table && this.table.setColumns(this.state.columns);
         }
     };
     default_1.prototype.render = function () {
         var _this = this;
         this.pickValidHTMLProps();
         var className = this.props.className;
-        return React.createElement("div", __assign({ ref: function (ref) { return (_this.ref = ref); }, "data-instance": this.mainId }, this.htmlProps, { className: className }));
+        return (React.createElement("div", __assign({ ref: function (ref) { return (_this.ref = ref); }, "data-instance": this.mainId }, this.htmlProps, { className: className })));
     };
     return default_1;
 }(React.Component));

--- a/lib/ReactTabulator.js
+++ b/lib/ReactTabulator.js
@@ -128,7 +128,7 @@ var default_1 = /** @class */ (function (_super) {
         });
     };
     default_1.prototype.componentWillUnmount = function () {
-        this.table && this.table.destroy();
+        this.table.destroy();
     };
     // React 16.5.x - "getDerivedStateFromProps" replaces both "componentWillMount" & "componentWillReceiveProps"
     // This function will be ignored when running with React 15.6.x
@@ -164,11 +164,11 @@ var default_1 = /** @class */ (function (_super) {
         // props data changed! (see: getDerivedStateFromProps)
         if (!Utils_1.isSameArray(prevState.data, this.state.data)) {
             // only when data is really different: call this.table.setData (will re-render table)
-            this.table && this.table.setData(this.state.data);
+            this.table.setData(this.state.data);
         }
         if (!Utils_1.isSameArray(prevState.columns, this.state.columns)) {
             // only when data is really different: call this.table.setData (will re-render table)
-            this.table && this.table.setColumns(this.state.columns);
+            this.table.setColumns(this.state.columns);
         }
     };
     default_1.prototype.render = function () {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "React Tabulator is based on tabulator - a JS table library with many advanced features.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "module": "es/index.js",
   "files": [
     "css",
     "es",

--- a/src/React15Tabulator.tsx
+++ b/src/React15Tabulator.tsx
@@ -52,7 +52,7 @@ export default class extends React.Component<IProps, Partial<IState>> {
   }
 
   componentWillUnmount() {
-    this.table.destroy();
+    this.table && this.table.destroy();
   }
 
   // this is for React 15.x only
@@ -60,13 +60,13 @@ export default class extends React.Component<IProps, Partial<IState>> {
     if (!isSameArray(this.state.data, props.data)) {
       // console.log('- data changed');
       this.setState({ data: props.data }, () => {
-        this.table.setData(this.state.data);
+        this.table && this.table.setData(this.state.data);
       });
     }
     if (!isSameArray(this.state.columns, props.columns)) {
       // console.log('- columns changed');
       this.setState({ columns: props.columns }, () => {
-        this.table.setColumns(this.state.columns);
+        this.table && this.table.setColumns(this.state.columns);
       });
     }
   }
@@ -84,6 +84,8 @@ export default class extends React.Component<IProps, Partial<IState>> {
     // console.log('*** render');
     this.pickValidHTMLProps();
     const { className } = this.props;
-    return <div ref={ref => (this.ref = ref)} data-instance={this.mainId} {...this.htmlProps} className={className} />;
+    return (
+      <div ref={(ref) => (this.ref = ref)} data-instance={this.mainId} {...this.htmlProps} className={className} />
+    );
   }
 }

--- a/src/ReactTabulator.tsx
+++ b/src/ReactTabulator.tsx
@@ -52,7 +52,7 @@ export default class extends React.Component<IProps, Partial<IState>> {
   }
 
   componentWillUnmount() {
-    this.table.destroy();
+    this.table && this.table.destroy();
   }
 
   // React 16.5.x - "getDerivedStateFromProps" replaces both "componentWillMount" & "componentWillReceiveProps"
@@ -90,11 +90,12 @@ export default class extends React.Component<IProps, Partial<IState>> {
     // props data changed! (see: getDerivedStateFromProps)
     if (!isSameArray(prevState.data, this.state.data)) {
       // only when data is really different: call this.table.setData (will re-render table)
-      this.table.setData(this.state.data);
+
+      this.table && this.table.setData(this.state.data);
     }
     if (!isSameArray(prevState.columns, this.state.columns)) {
       // only when data is really different: call this.table.setData (will re-render table)
-      this.table.setColumns(this.state.columns);
+      this.table && this.table.setColumns(this.state.columns);
     }
   }
 
@@ -110,6 +111,8 @@ export default class extends React.Component<IProps, Partial<IState>> {
   render() {
     this.pickValidHTMLProps();
     const { className } = this.props;
-    return <div ref={ref => (this.ref = ref)} data-instance={this.mainId} {...this.htmlProps} className={className} />;
+    return (
+      <div ref={(ref) => (this.ref = ref)} data-instance={this.mainId} {...this.htmlProps} className={className} />
+    );
   }
 }


### PR DESCRIPTION
Motivation for these fixes is that this library when used with vite4.x caused crashes in production

The patch makes sure usage of methods defined on `this.table` are always made after checking that `this.table` is not null/undefined